### PR TITLE
Cluster name limit is 32 chars

### DIFF
--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -46,7 +46,7 @@ on:
 
 env:
   K3S_VERSION: v1.25.9-k3s1
-  K3D_CLUSTER_NAME: ${{ github.repository_owner }}-${{ github.event.repository.name }}-github-runner
+  K3D_CLUSTER_NAME: ${{ github.repository_owner }}-${{ github.event.repository.name }}-runner
 
 jobs:
   e2e:


### PR DESCRIPTION
Cluster name is too long after moving `ui` -> `kubewarden-ui`

Fix for: https://github.com/kubewarden/kubewarden-ui/actions/runs/5597554304/jobs/10236058674