### PR TITLE
Add data-testid to elements for e2e within dashboard repo

### DIFF
--- a/pkg/kubewarden/chart/kubewarden/admission/ContextAware/Resource.vue
+++ b/pkg/kubewarden/chart/kubewarden/admission/ContextAware/Resource.vue
@@ -115,6 +115,7 @@ export default {
     <div class="col span-4">
       <LabeledSelect
         v-model="value.apiVersion"
+        data-testid="kw-policy-context-resource-apiversion-select"
         :disabled="disabled"
         :clearable="false"
         :searchable="true"
@@ -130,6 +131,7 @@ export default {
     <div class="col span-4">
       <LabeledSelect
         v-model="value.kind"
+        data-testid="kw-policy-context-resource-kind-select"
         :disabled="disabled"
         :clearable="false"
         :searchable="true"

--- a/pkg/kubewarden/chart/kubewarden/admission/ContextAware/index.vue
+++ b/pkg/kubewarden/chart/kubewarden/admission/ContextAware/index.vue
@@ -94,6 +94,7 @@ export default {
   <div v-else>
     <p>{{ t('kubewarden.policyConfig.contextAware.description') }}</p>
     <Banner
+      data-testid="kw-policy-config-context-banner"
       class="mb-20"
       color="warning"
       :label="t('kubewarden.policyConfig.contextAware.warning')"
@@ -103,19 +104,26 @@ export default {
       <Resource
         ref="lastResource"
         v-model="contextAwareResources[index]"
+        :data-testid="`kw-policy-config-context-resource-${ index }`"
         :disabled="disabledcontextAwareResources"
         :mode="mode"
         :api-group-versions="apiGroupVersions"
       >
         <template v-if="!isView && !disabledcontextAwareResources" #removeResource>
-          <button type="button" class="btn role-link p-0" @click="removeResource(index)">
+          <button :data-testid="`kw-policy-config-context-remove-${ index }`" type="button" class="btn role-link p-0" @click="removeResource(index)">
             {{ t('kubewarden.policyConfig.contextAware.resource.remove') }}
           </button>
         </template>
       </Resource>
     </div>
 
-    <button v-if="!isView && !disabledcontextAwareResources" type="button" class="btn role-tertiary add" @click="addResource">
+    <button
+      v-if="!isView && !disabledcontextAwareResources"
+      data-testid="kw-policy-config-context-add"
+      type="button"
+      class="btn role-tertiary add"
+      @click="addResource"
+    >
       {{ t('kubewarden.policyConfig.contextAware.resource.add') }}
     </button>
   </div>

--- a/pkg/kubewarden/chart/kubewarden/admission/General.vue
+++ b/pkg/kubewarden/chart/kubewarden/admission/General.vue
@@ -149,6 +149,7 @@ export default {
     <div class="row">
       <div class="col span-12">
         <NameNsDescription
+          data-testid="kw-policy-general-name-input"
           :mode="mode"
           :value="policy"
           :description-hidden="true"
@@ -163,6 +164,7 @@ export default {
         <div class="col span-6">
           <LabeledSelect
             v-model="policy.spec.policyServer"
+            data-testid="kw-policy-general-ps-input"
             :value="value"
             :mode="mode"
             :options="policyServerOptions"
@@ -173,6 +175,7 @@ export default {
         <div class="col span-6">
           <LabeledInput
             v-model="policy.spec.module"
+            data-testid="kw-policy-general-module-input"
             :mode="mode"
             :label="t('kubewarden.policyConfig.module.label')"
             :tooltip="t('kubewarden.policyConfig.module.tooltip')"
@@ -184,6 +187,7 @@ export default {
         <div class="col span-6">
           <RadioGroup
             v-model="policy.spec.mode"
+            data-testid="kw-policy-general-mode-input"
             name="mode"
             :disabled="modeDisabled"
             :options="['monitor', 'protect']"
@@ -192,13 +196,19 @@ export default {
             :labels="['Monitor', 'Protect']"
             :tooltip="t('kubewarden.policyConfig.mode.tooltip')"
           />
-          <Banner v-if="showModeBanner" color="warning" :label="t('kubewarden.policyConfig.mode.warning')" />
+          <Banner
+            v-if="showModeBanner"
+            data-testid="kw-policy-general-mode-banner"
+            color="warning"
+            :label="t('kubewarden.policyConfig.mode.warning')"
+          />
         </div>
 
         <template v-if="isGlobal">
           <div class="col span-6">
             <RadioGroup
               v-model="policy.ignoreRancherNamespaces"
+              data-testid="kw-policy-general-ignore-ns-input"
               name="ignoreRancherNamespaces"
               :options="[true, false]"
               :mode="mode"

--- a/pkg/kubewarden/chart/kubewarden/admission/Rules/Rule.vue
+++ b/pkg/kubewarden/chart/kubewarden/admission/Rules/Rule.vue
@@ -204,6 +204,7 @@ export default {
     <div v-if="isGlobalRule">
       <LabeledSelect
         v-model="value.scope"
+        data-testid="kw-policy-rules-rule-scope-select"
         :disabled="disabled"
         :label="t('kubewarden.policyConfig.scope.label')"
         :tooltip="t('kubewarden.policyConfig.scope.tooltip')"
@@ -216,6 +217,7 @@ export default {
     <div>
       <LabeledSelect
         v-model="apiGroupValues"
+        data-testid="kw-policy-rules-rule-apigroup-select"
         :disabled="disabled"
         :label="t('kubewarden.policyConfig.apiGroups.label')"
         :tooltip="t('kubewarden.policyConfig.apiGroups.tooltip')"
@@ -230,6 +232,7 @@ export default {
     <div>
       <LabeledSelect
         v-model="value.resources"
+        data-testid="kw-policy-rules-rule-resources-select"
         :disabled="disabled"
         :label="t('kubewarden.policyConfig.resources.label')"
         :mode="mode"
@@ -244,6 +247,7 @@ export default {
     <div>
       <LabeledSelect
         v-model="value.apiVersions"
+        data-testid="kw-policy-rules-rule-apiversions-select"
         :disabled="disabled"
         :clearable="true"
         :searchable="false"
@@ -260,6 +264,7 @@ export default {
     <div>
       <LabeledSelect
         v-model="value.operations"
+        data-testid="kw-policy-rules-rule-operations-select"
         :disabled="disabled"
         :label="t('kubewarden.policyConfig.operations.label')"
         :mode="mode"

--- a/pkg/kubewarden/chart/kubewarden/admission/Rules/index.vue
+++ b/pkg/kubewarden/chart/kubewarden/admission/Rules/index.vue
@@ -76,19 +76,20 @@ export default {
       <Rule
         ref="lastRule"
         v-model="rules[index]"
+        :data-testid="`kw-policy-rules-rule-${ index }`"
         :disabled="disabledRules"
         :mode="mode"
         :api-groups="apiGroups"
       >
         <template v-if="!isView && !disabledRules" #removeRule>
-          <button type="button" class="btn role-link p-0" @click="removeRule(index)">
+          <button :data-testid="`kw-policy-rules-rule-remove-${ index }`" type="button" class="btn role-link p-0" @click="removeRule(index)">
             {{ t('kubewarden.policyConfig.rules.remove') }}
           </button>
         </template>
       </Rule>
     </div>
 
-    <button v-if="!isView && !disabledRules" type="button" class="btn role-tertiary add" @click="addRule">
+    <button v-if="!isView && !disabledRules" data-testid="kw-policy-rules-rule-add" type="button" class="btn role-tertiary add" @click="addRule">
       {{ t('kubewarden.policyConfig.rules.add') }}
     </button>
   </div>

--- a/pkg/kubewarden/chart/kubewarden/admission/Settings.vue
+++ b/pkg/kubewarden/chart/kubewarden/admission/Settings.vue
@@ -41,6 +41,7 @@ export default {
     <YamlEditor
       ref="yamleditor"
       v-model="settingsYaml"
+      data-testid="kw-policy-config-settings-yaml-editor"
       class="yaml-editor"
       initial-yaml-values="# Additional Settings YAML \n"
       :editor-mode="isView ? 'VIEW_CODE' : 'EDIT_CODE'"

--- a/pkg/kubewarden/chart/kubewarden/admission/index.vue
+++ b/pkg/kubewarden/chart/kubewarden/admission/index.vue
@@ -102,15 +102,15 @@ export default {
 <template>
   <div>
     <Tab name="general" :label="t('kubewarden.policyConfig.tabs.general')" :weight="99">
-      <General v-model="chartValues" :mode="mode" :target-namespace="targetNamespace" />
+      <General v-model="chartValues" data-testid="kw-policy-config-general-tab" :mode="mode" :target-namespace="targetNamespace" />
     </Tab>
     <Tab name="rules" :label="t('kubewarden.policyConfig.tabs.rules')" :weight="98">
-      <Rules v-model="chartValues" :mode="mode" />
+      <Rules v-model="chartValues" data-testid="kw-policy-config-rules-tab" :mode="mode" />
     </Tab>
 
     <template v-if="showContextAware">
       <Tab name="contextAware" :label="t('kubewarden.policyConfig.tabs.contextAware')" :weight="97">
-        <ContextAware v-model="chartValues" :mode="mode" />
+        <ContextAware v-model="chartValues" data-testid="kw-policy-config-context-tab" :mode="mode" />
       </Tab>
     </template>
 
@@ -118,6 +118,7 @@ export default {
       <Tab name="settings" :label="t('kubewarden.policyConfig.tabs.settings')" :weight="96">
         <Settings
           v-model="chartValues"
+          data-testid="kw-policy-config-settings-tab"
           @updateSettings="settingsChanged($event)"
         />
       </Tab>
@@ -128,6 +129,7 @@ export default {
       <Tab name="Settings" label="Settings" :weight="96">
         <Questions
           v-model="chartValues.policy.spec.settings"
+          data-testid="kw-policy-config-questions-tab"
           :mode="mode"
           :source="chartValues"
           tabbed="never"

--- a/pkg/kubewarden/chart/kubewarden/policy-server/General.vue
+++ b/pkg/kubewarden/chart/kubewarden/policy-server/General.vue
@@ -93,6 +93,7 @@ export default {
       <div class="col span-6 mb-20">
         <LabeledInput
           v-model="value.metadata.name"
+          data-testid="ps-config-name-input"
           :mode="mode"
           :label="t('nameNsDescription.name.label')"
           :placeholder="t('nameNsDescription.name.placeholder')"
@@ -111,6 +112,7 @@ export default {
         />
         <RadioGroup
           v-model="defaultImage"
+          data-testid="ps-config-default-image-button"
           name="defaultImage"
           :options="[true, false]"
           :mode="mode"
@@ -122,6 +124,7 @@ export default {
         <template v-if="!defaultImage">
           <LabeledInput
             v-model="value.spec.image"
+            data-testid="ps-config-image-input"
             :mode="mode"
             :label="t('kubewarden.policyServerConfig.image.label')"
             :tooltip="t('kubewarden.policyServerConfig.image.tooltip')"
@@ -134,6 +137,7 @@ export default {
       <div class="col span-12">
         <ServiceNameSelect
           v-model="value.spec.serviceAccountName"
+          data-testid="ps-config-service-account-input"
           :mode="mode"
           :select-label="t('workload.serviceAccountName.label')"
           :select-placeholder="t('workload.serviceAccountName.label')"
@@ -154,6 +158,7 @@ export default {
         </h3>
         <LabeledInput
           v-model.number="value.spec.replicas"
+          data-testid="ps-config-replicas-input"
           type="number"
           min="0"
           required

--- a/pkg/kubewarden/chart/kubewarden/policy-server/Registry/Authority.vue
+++ b/pkg/kubewarden/chart/kubewarden/policy-server/Registry/Authority.vue
@@ -64,6 +64,7 @@ export default {
       <LabeledInput
         ref="authorityName"
         v-model="value.registryName"
+        data-testid="ps-config-authority-name-input"
         type="multiline"
         :label="t('kubewarden.policyServerConfig.sourceAuthorities.endpoint')"
         class="mb-20 mt-20"
@@ -79,6 +80,7 @@ export default {
             <LabeledInput
               ref="authorityCert"
               v-model="value.certs[cIndex]"
+              :data-testid="`ps-config-authority-cert-input-${ cIndex }`"
               type="multiline"
               :label="t('kubewarden.policyServerConfig.sourceAuthorities.certificate.label')"
               class="p-10 col span-6"
@@ -90,6 +92,7 @@ export default {
 
             <div class="remove">
               <button
+                :data-testid="`ps-config-authority-cert-remove-button-${ cIndex }`"
                 type="button"
                 :disabled="isView"
                 class="btn role-link remove"
@@ -102,6 +105,7 @@ export default {
         </template>
 
         <button
+          data-testid="ps-config-authority-cert-add-button"
           type="button"
           class="btn role-tertiary add"
           :disabled="isView"
@@ -111,6 +115,7 @@ export default {
         </button>
 
         <FileSelector
+          data-testid="ps-config-authority-select-file"
           class="btn role-link"
           :label="t('kubewarden.policyServerConfig.sourceAuthorities.certificate.file')"
           :disabled="isView"

--- a/pkg/kubewarden/chart/kubewarden/policy-server/Registry/Index.vue
+++ b/pkg/kubewarden/chart/kubewarden/policy-server/Registry/Index.vue
@@ -52,9 +52,10 @@ export default {
   <div class="mt-10 mb-20">
     <div class="row">
       <Banner
+        v-clean-html="t('kubewarden.policyServerConfig.registry.description', {}, true)"
+        data-testid="ps-config-registry-banner"
         class="type-banner mb-20 mt-0"
         color="info"
-        v-clean-html="t('kubewarden.policyServerConfig.registry.description', {}, true)"
       />
     </div>
 
@@ -66,6 +67,7 @@ export default {
         <div class="col span-6">
           <ArrayList
             v-model="insecureSources"
+            data-testid="ps-config-insecure-sources-input"
             :mode="mode"
             :add-allowed="true"
             :add-label="t('kubewarden.policyServerConfig.insecureSources.addLabel')"

--- a/pkg/kubewarden/chart/kubewarden/policy-server/Registry/SourceAuthorities.vue
+++ b/pkg/kubewarden/chart/kubewarden/policy-server/Registry/SourceAuthorities.vue
@@ -84,11 +84,14 @@ export default {
 <template>
   <div class="row">
     <div class="col span-12">
-      <h3>{{ t('kubewarden.policyServerConfig.sourceAuthorities.title') }}</h3>
+      <h3 data-testid="ps-config-source-authorities-title">
+        {{ t('kubewarden.policyServerConfig.sourceAuthorities.title') }}
+      </h3>
       <template v-for="(row, index) in rows">
         <Authority ref="authority" :key="index" v-model="rows[index]" :mode="mode" @update="updateAuthority($event, index)">
           <template #remove>
             <button
+              :data-testid="`ps-config-authority-remove-button-${ index }`"
               type="button"
               :disabled="isView"
               class="btn role-link remove btn-sm"
@@ -101,6 +104,7 @@ export default {
       </template>
 
       <button
+        data-testid="ps-config-source-authorities-add-button"
         type="button"
         class="btn role-tertiary add"
         :disabled="isView"

--- a/pkg/kubewarden/chart/kubewarden/policy-server/Verification.vue
+++ b/pkg/kubewarden/chart/kubewarden/policy-server/Verification.vue
@@ -30,15 +30,17 @@ export default {
   <div>
     <div class="row">
       <Banner
+        v-clean-html="t('kubewarden.policyServerConfig.verification.description', {}, true)"
+        data-testid="ps-config-verification-banner"
         class="type-banner mb-20 mt-0"
         color="info"
-        v-clean-html="t('kubewarden.policyServerConfig.verification.description', {}, true)"
       />
     </div>
     <div class="row">
       <div class="col span-6">
         <LabeledSelect
           v-model="value.verificationConfig"
+          data-testid="ps-config-verification-select"
           :mode="mode"
           :label="t('kubewarden.policyServerConfig.verification.label')"
           :options="configMaps"

--- a/pkg/kubewarden/chart/kubewarden/policy-server/index.vue
+++ b/pkg/kubewarden/chart/kubewarden/policy-server/index.vue
@@ -109,16 +109,16 @@ export default {
   <Loading v-if="$fetchState.pending" mode="relative" />
   <div v-else>
     <Tab name="general" label-key="kubewarden.tabs.general.label" :weight="99">
-      <General v-model="chartValues" :mode="mode" :service-accounts="serviceAccounts" />
+      <General v-model="chartValues" data-testid="ps-config-general-tab" :mode="mode" :service-accounts="serviceAccounts" />
     </Tab>
     <Tab name="labels" label-key="generic.labelsAndAnnotations" :weight="98">
-      <Labels v-model="resourceClone" :mode="mode" />
+      <Labels v-model="resourceClone" data-testid="ps-config-labels-tab" :mode="mode" />
     </Tab>
     <Tab name="verification" label-key="kubewarden.tabs.verification.label" :weight="97">
-      <Verification :value="chartValues.spec" :mode="mode" :config-maps="configMaps" />
+      <Verification data-testid="ps-config-verification-tab" :value="chartValues.spec" :mode="mode" :config-maps="configMaps" />
     </Tab>
     <Tab name="registry" label-key="kubewarden.tabs.registry.label" :weight="96" @active="refresh">
-      <Registry ref="registry" :value="chartValues.spec" :mode="mode" />
+      <Registry ref="registry" data-testid="ps-config-registry-tab" :value="chartValues.spec" :mode="mode" />
     </Tab>
   </div>
 </template>

--- a/pkg/kubewarden/components/Dashboard/DashboardView.vue
+++ b/pkg/kubewarden/components/Dashboard/DashboardView.vue
@@ -162,7 +162,9 @@ export default {
   <div v-else class="dashboard">
     <div class="head">
       <div class="head-title">
-        <h1>{{ t('kubewarden.dashboard.intro') }}</h1>
+        <h1 data-testid="kw-dashboard-title">
+          {{ t('kubewarden.dashboard.intro') }}
+        </h1>
         <span v-if="version">{{ version }}</span>
       </div>
 
@@ -205,6 +207,7 @@ export default {
           <span v-if="index === 0">
             <slot>
               <ConsumptionGauge
+                data-testid="kw-dashboard-ps-gauge"
                 resource-name="Active"
                 :color-stops="colorStops"
                 :capacity="policyServers.total"
@@ -219,6 +222,7 @@ export default {
           <span v-if="index === 1">
             <slot>
               <ConsumptionGauge
+                data-testid="kw-dashboard-ap-gauge"
                 resource-name="Active"
                 :color-stops="colorStops"
                 :capacity="namespacedGuages.total"
@@ -238,6 +242,7 @@ export default {
           <span v-if="index === 2">
             <slot>
               <ConsumptionGauge
+                data-testid="kw-dashboard-cap-gauge"
                 resource-name="Active"
                 :color-stops="colorStops"
                 :capacity="globalGuages.total"

--- a/pkg/kubewarden/components/Dashboard/InstallView.vue
+++ b/pkg/kubewarden/components/Dashboard/InstallView.vue
@@ -240,13 +240,13 @@ export default {
           height="64"
         />
       </div>
-      <h1 class="mb-20">
+      <h1 class="mb-20" data-testid="kw-install-title">
         {{ t("kubewarden.title") }}
       </h1>
       <div class="description">
         {{ t("kubewarden.dashboard.description") }}
       </div>
-      <button v-if="!hasSchema" class="btn role-primary mt-20" @click="install = true">
+      <button v-if="!hasSchema" class="btn role-primary mt-20" data-testid="kw-initial-install-button" @click="install = true">
         {{ t("kubewarden.dashboard.appInstall.button") }}
       </button>
     </div>
@@ -258,12 +258,12 @@ export default {
           class="mb-20 mt-20"
           color="warning"
         >
-          <span>{{ t('kubewarden.dashboard.prerequisites.airGapped.warning') }}</span>
+          <span data-testid="kw-install-ag-warning">{{ t('kubewarden.dashboard.prerequisites.airGapped.warning') }}</span>
           <span v-html="t('kubewarden.dashboard.prerequisites.airGapped.docs', {}, true)"></span>
         </Banner>
         <InstallWizard ref="wizard" :init-step-index="initStepIndex" :steps="installSteps">
           <template #certmanager>
-            <h2 class="mt-20 mb-10">
+            <h2 class="mt-20 mb-10" data-testid="kw-ag-cm-title">
               {{ t("kubewarden.dashboard.prerequisites.certManager.title") }}
             </h2>
             <p class="mb-20">
@@ -283,7 +283,7 @@ export default {
 
           <template #install>
             <template v-if="!controllerChart">
-              <h2 class="mt-20 mb-10">
+              <h2 class="mt-20 mb-10" data-testid="kw-ag-repo-title">
                 {{ t("kubewarden.dashboard.prerequisites.repository.title") }}
               </h2>
               <p class="mb-20">
@@ -292,7 +292,7 @@ export default {
             </template>
 
             <template v-else>
-              <h2 class="mt-20 mb-10">
+              <h2 class="mt-20 mb-10" data-testid="kw-ag-app-install-title">
                 {{ t("kubewarden.dashboard.appInstall.title") }}
               </h2>
               <p class="mb-20">
@@ -317,6 +317,7 @@ export default {
                   <button
                     class="btn role-primary mt-20"
                     :disabled="!controllerChart"
+                    data-testid="kw-ag-app-install-button"
                     @click.prevent="chartRoute"
                   >
                     {{ t("kubewarden.dashboard.appInstall.button") }}
@@ -332,7 +333,7 @@ export default {
       <template v-else>
         <InstallWizard ref="wizard" :init-step-index="initStepIndex" :steps="installSteps">
           <template #certmanager>
-            <h2 class="mt-20 mb-10">
+            <h2 class="mt-20 mb-10" data-testid="kw-cm-title">
               {{ t("kubewarden.dashboard.prerequisites.certManager.title") }}
             </h2>
             <p class="mb-20">
@@ -340,10 +341,11 @@ export default {
             </p>
 
             <p v-clean-html="t('kubewarden.dashboard.prerequisites.certManager.manualStep', null, true)"></p>
-            <CopyCode class="m-10 p-10">
+            <CopyCode class="m-10 p-10" data-testid="kw-cm-copy-code">
               {{ t("kubewarden.dashboard.prerequisites.certManager.applyCommand") }}
             </CopyCode>
             <button
+              data-testid="kw-cm-open-shell"
               :disabled="!shellEnabled"
               type="button"
               class="btn role-secondary"
@@ -364,18 +366,18 @@ export default {
 
           <template #install>
             <template v-if="!kubewardenRepo">
-              <h2 class="mt-20 mb-10">
+              <h2 class="mt-20 mb-10" data-testid="kw-repo-title">
                 {{ t("kubewarden.dashboard.prerequisites.repository.title") }}
               </h2>
               <p class="mb-20">
                 {{ t("kubewarden.dashboard.prerequisites.repository.description") }}
               </p>
 
-              <AsyncButton mode="kubewardenRepository" @click="addRepository" />
+              <AsyncButton mode="kubewardenRepository" data-testid="kw-repo-add-button" @click="addRepository" />
             </template>
 
             <template v-else>
-              <h2 class="mt-20 mb-10">
+              <h2 class="mt-20 mb-10" data-testid="kw-app-install-title">
                 {{ t("kubewarden.dashboard.appInstall.title") }}
               </h2>
               <p class="mb-20">
@@ -398,6 +400,7 @@ export default {
 
                 <template v-else>
                   <button
+                    data-testid="kw-app-install-button"
                     class="btn role-primary mt-20"
                     :disabled="!controllerChart"
                     @click.prevent="chartRoute"

--- a/pkg/kubewarden/components/DefaultsBanner.vue
+++ b/pkg/kubewarden/components/DefaultsBanner.vue
@@ -90,6 +90,7 @@ export default {
 
 <template>
   <Banner
+    data-testid="kw-defaults-banner"
     class="mb-20 mt-0"
     color="info"
     :closable="true"
@@ -97,6 +98,7 @@ export default {
   >
     <span v-clean-html="t('kubewarden.policyServer.noDefaultsInstalled.description', {}, true)" />
     <button
+      data-testid="kw-defaults-banner-button"
       class="btn role-primary ml-10"
       @click.prevent="chartRoute"
     >

--- a/pkg/kubewarden/components/MetricsBanner.vue
+++ b/pkg/kubewarden/components/MetricsBanner.vue
@@ -67,9 +67,10 @@ export default {
 
 <template>
   <div v-if="!monitoringStatus.installed">
-    <Banner color="warning">
+    <Banner color="warning" data-testid="kw-metrics-not-installed-banner">
       <span v-clean-html="t('kubewarden.monitoring.notInstalled', {}, true)" />
       <button
+        data-testid="kw-metrics-banner-install-button"
         class="btn role-primary ml-10"
         @click.prevent="chartRoute"
       >
@@ -85,6 +86,7 @@ export default {
           {{ t('kubewarden.metrics.notInstalled' ) }}
         </p>
         <AsyncButton
+          data-testid="kw-metrics-banner-add-dashboard-button"
           mode="grafanaDashboard"
           @click="$emit('add', $event)"
         />
@@ -104,7 +106,7 @@ export default {
   <div v-else-if="!metricsService">
     <Banner color="error">
       <i class="icon icon-checkmark mr-10" />
-      <span class="mb-20">
+      <span class="mb-20" data-testid="kw-metrics-banner-no-service">
         {{ t('kubewarden.metrics.noService' ) }}
       </span>
     </Banner>

--- a/pkg/kubewarden/components/Policies/Create.vue
+++ b/pkg/kubewarden/components/Policies/Create.vue
@@ -431,6 +431,7 @@ export default ({
   <div v-else>
     <template v-if="!hideArtifactHubBanner">
       <Banner
+        data-testid="kw-policy-create-ah-banner"
         class="type-banner mb-20 mt-0"
         color="warning"
         :closable="true"
@@ -444,6 +445,7 @@ export default ({
     </template>
     <template v-if="!hideAirgapBanner">
       <Banner
+        data-testid="kw-policy-create-ag-banner"
         class="type-banner mb-20 mt-0"
         color="warning"
         :closable="true"
@@ -456,6 +458,7 @@ export default ({
       v-if="value && !loadingPackages"
       ref="wizard"
       v-model="value"
+      data-testid="kw-policy-create-wizard"
       :errors="errors"
       :steps="steps"
       :edit-first-step="true"
@@ -467,9 +470,9 @@ export default ({
       @finish="finish"
     >
       <template #policies>
-        <PolicyGrid :value="packages" @selectType="selectType($event)">
+        <PolicyGrid data-testid="kw-policy-create-grid" :value="packages" @selectType="selectType($event)">
           <template #customSubtype>
-            <div class="subtype custom" @click="selectType('custom')">
+            <div data-testid="kw-grid-subtype-card-custom" class="subtype custom" @click="selectType('custom')">
               <div class="subtype__metadata">
                 <div class="subtype__badge" :style="{ 'background-color': 'var(--darker)' }">
                   <label>{{ t('kubewarden.customPolicy.badge') }}</label>
@@ -489,7 +492,7 @@ export default ({
       </template>
 
       <template #readme>
-        <ChartReadme v-if="packageValues" :version-info="packageValues" class="mb-20" />
+        <ChartReadme v-if="packageValues" data-testid="kw-policy-create-readme" :version-info="packageValues" class="mb-20" />
       </template>
 
       <template #values>
@@ -506,6 +509,7 @@ export default ({
 
       <template #finish>
         <AsyncButton
+          data-testid="kw-policy-create-finish-button"
           :disabled="!canFinish"
           mode="finish"
           @click="finish"

--- a/pkg/kubewarden/components/Policies/PolicyDetail.vue
+++ b/pkg/kubewarden/components/Policies/PolicyDetail.vue
@@ -137,13 +137,13 @@ export default {
     <div class="mb-20">
       <h3>{{ t('namespace.resources') }}</h3>
     </div>
-    <ResourceTabs v-model="value" :mode="mode" :need-related="hasRelationships">
+    <ResourceTabs v-model="value" data-testid="kw-policy-detail-tabs" :mode="mode" :need-related="hasRelationships">
       <Tab v-if="hasRules" name="policy-rules" label="Rules" :weight="99">
-        <RulesTable :rows="rulesRows" />
+        <RulesTable data-testid="kw-polity-detail-rules-table" :rows="rulesRows" />
       </Tab>
 
       <Tab name="policy-tracing" label="Tracing" :weight="98">
-        <TraceTable :rows="tracesRows">
+        <TraceTable data-testid="kw-policy-detail-trace-table" :rows="tracesRows">
           <template #traceBanner>
             <Banner v-if="emptyTraces" color="warning">
               <span v-if="!jaegerService" v-clean-html="t('kubewarden.tracing.noJaeger', {}, true)" />

--- a/pkg/kubewarden/components/Policies/PolicyGrid.vue
+++ b/pkg/kubewarden/components/Policies/PolicyGrid.vue
@@ -186,6 +186,7 @@ export default {
       <LabeledSelect
         v-if="providerOptions.length"
         v-model="provider"
+        data-testid="kw-grid-filter-provider"
         :clearable="true"
         :taggable="true"
         :mode="mode"
@@ -197,6 +198,7 @@ export default {
 
       <LabeledSelect
         v-model="keywords"
+        data-testid="kw-grid-filter-keywords"
         :clearable="true"
         :taggable="true"
         :mode="mode"
@@ -208,6 +210,7 @@ export default {
 
       <LabeledSelect
         v-model="category"
+        data-testid="kw-grid-filter-category"
         :clearable="true"
         :searchable="false"
         :mode="mode"
@@ -221,12 +224,14 @@ export default {
       <input
         ref="searchQuery"
         v-model="searchQuery"
+        data-testid="kw-grid-filter-search"
         type="search"
         class="input-sm filter__search"
         :placeholder="t('catalog.charts.search')"
       >
       <button
         ref="btn"
+        data-testid="kw-grid-filter-refresh"
         class="btn, btn-sm, role-primary"
         type="button"
         @click="refresh"
@@ -241,6 +246,7 @@ export default {
       <div
         v-for="subtype in filteredSubtypes"
         :key="subtype.package_id"
+        :data-testid="`kw-grid-subtype-card-${ subtype.package_id }`"
         class="subtype"
         @click="$emit('selectType', subtype)"
       >

--- a/pkg/kubewarden/components/Policies/Values.vue
+++ b/pkg/kubewarden/components/Policies/Values.vue
@@ -158,6 +158,7 @@ export default {
     <div v-if="isCreate" class="step__values__controls">
       <ButtonGroup
         v-model="yamlOption"
+        data-testid="kw-policy-config-yaml-option"
         :options="YAML_OPTIONS"
         inactive-class="bg-disabled btn-sm"
         active-class="bg-primary btn-sm"
@@ -186,6 +187,7 @@ export default {
           <YamlEditor
             ref="yaml"
             v-model="currentYamlValues"
+            data-testid="kw-policy-config-yaml-editor"
             class="step__values__content"
             :scrolling="true"
             :initial-yaml-values="originalYamlValues"
@@ -197,6 +199,7 @@ export default {
 
         <ResourceCancelModal
           ref="cancelModal"
+          data-testid="kw-policy-config-yaml-cancel"
           :is-cancel-modal="false"
           :is-form="true"
           @cancel-cancel="preYamlOption = yamlOption"

--- a/pkg/kubewarden/components/RulesTable.vue
+++ b/pkg/kubewarden/components/RulesTable.vue
@@ -30,6 +30,7 @@ export default {
   <div>
     <SortableTable
       v-if="rows.length > 0"
+      data-testid="kw-policy-rules-sortable-table"
       :rows="rows"
       :headers="RULE_HEADERS"
       :table-actions="false"

--- a/pkg/kubewarden/components/TraceBanner.vue
+++ b/pkg/kubewarden/components/TraceBanner.vue
@@ -20,9 +20,9 @@ export default {
 <template>
   <div>
     <Banner color="warning">
-      <span v-if="!openTelemetryService" v-clean-html="t('kubewarden.tracing.noOpenTelemetry', {}, true)" />
-      <span v-else-if="!jaegerService" v-clean-html="t('kubewarden.tracing.noJaeger', {}, true)" />
-      <span v-else>{{ t('kubewarden.tracing.noRelatedTraces') }}</span>
+      <span v-if="!openTelemetryService" v-clean-html="t('kubewarden.tracing.noOpenTelemetry', {}, true)" data-testid="kw-trace-banner-no-telemetry" />
+      <span v-else-if="!jaegerService" v-clean-html="t('kubewarden.tracing.noJaeger', {}, true)" data-testid="kw-trace-banner-no-jaeger" />
+      <span v-else data-testid="kw-trace-banner-no-traces">{{ t('kubewarden.tracing.noRelatedTraces') }}</span>
     </Banner>
   </div>
 </template>

--- a/pkg/kubewarden/detail/policies.kubewarden.io.policyserver.vue
+++ b/pkg/kubewarden/detail/policies.kubewarden.io.policyserver.vue
@@ -187,7 +187,7 @@ export default {
       <div class="row">
         <template>
           <div class="col span-6">
-            <h3>
+            <h3 data-testid="kw-ps-detail-status-title">
               {{ t('kubewarden.policyServer.policyGauge.byStatus') }}
             </h3>
             <div class="gauges mb-20">
@@ -233,10 +233,12 @@ export default {
             :groupable="true"
             :group-by="groupPreference"
             :table-actions="true"
+            data-testid="kw-ps-detail-related-policies-list"
           >
             <template #col:operation="{ row }">
               <td>
                 <BadgeState
+                  :data-testid="`kw-ps-detail-${ row.id }-state`"
                   :label="row.operation"
                   :color="color(row.operation)"
                 />
@@ -259,6 +261,7 @@ export default {
         <template v-if="metricsService" #default="props">
           <DashboardMetrics
             v-if="props.active"
+            data-testid="kw-ps-metrics-dashboard"
             :detail-url="metricsProxy"
             :summary-url="metricsProxy"
             graph-height="825px"

--- a/pkg/kubewarden/list/policies.kubewarden.io.admissionpolicy.vue
+++ b/pkg/kubewarden/list/policies.kubewarden.io.admissionpolicy.vue
@@ -40,11 +40,12 @@ export default {
   <Loading v-if="$fetchState.pending" />
   <div v-else>
     <Banner
+      data-testid="kw-ap-list-banner"
       class="type-banner mb-20 mt-0"
       color="info"
       :label="t('kubewarden.admissionPolicy.description')"
     />
 
-    <PolicyList :resource="resource" :rows="rows" :schema="schema" />
+    <PolicyList data-testid="kw-ap-policy-list" :resource="resource" :rows="rows" :schema="schema" />
   </div>
 </template>

--- a/pkg/kubewarden/list/policies.kubewarden.io.clusteradmissionpolicy.vue
+++ b/pkg/kubewarden/list/policies.kubewarden.io.clusteradmissionpolicy.vue
@@ -40,11 +40,12 @@ export default {
   <Loading v-if="$fetchState.pending" />
   <div v-else>
     <Banner
+      data-testid="kw-cap-list-banner"
       class="type-banner mb-20 mt-0"
       color="info"
       :label="t('kubewarden.clusterAdmissionPolicy.description')"
     />
 
-    <PolicyList :resource="resource" :rows="rows" :schema="schema" />
+    <PolicyList data-testid="kw-cap-policy-list" :resource="resource" :rows="rows" :schema="schema" />
   </div>
 </template>

--- a/pkg/kubewarden/list/policies.kubewarden.io.policyserver.vue
+++ b/pkg/kubewarden/list/policies.kubewarden.io.policyserver.vue
@@ -67,6 +67,7 @@ export default {
     <ResourceTable
       :schema="schema"
       :rows="rows"
+      data-testid="kw-ps-resource-table"
     />
   </div>
 </template>


### PR DESCRIPTION
## Description

This adds the `data-testid` attribute to elements across the ui for e2e testing within the Rancher/Dashboard repository.