### PR TITLE
Add page reload wrapper for unstable rancher parts

### DIFF
--- a/tests/e2e/00-installation.spec.ts
+++ b/tests/e2e/00-installation.spec.ts
@@ -25,23 +25,17 @@ test('00 Initial rancher setup', async({ page, ui }) => {
   await rancher.setExtensionDeveloperFeatures(true);
 });
 
-test('01 Enable extension support', async({ page }) => {
+test('01 Enable extension support', async({ page, ui }) => {
   const extensions = new RancherExtensionsPage(page);
 
   await extensions.enable(ORIGIN == 'released');
 
   // Wait for default list of extensions
   if (ORIGIN == 'released') {
-    await extensions.selectTab('All');
-    try {
-      // Extension list is usually empty without page refresh
-      await expect(page.locator('.plugin', { hasText: 'Kubewarden' } )).toBeVisible();
-    } catch (e) {
-      console.log('Reload: Not showing kubewarden extension');
-      await page.reload();
-      await extensions.selectTab('All');
-      await expect(page.locator('.plugin', { hasText: 'Kubewarden' } )).toBeVisible();
-    }
+    await ui.withReload(async () => {
+      await extensions.selectTab('All')
+      await expect(page.locator('.plugin', { hasText: 'Kubewarden' } )).toBeVisible()
+    }, 'Not showing kubewarden extension')
   }
 });
 
@@ -63,20 +57,16 @@ test('02 Install extension', async({ page }) => {
   }
 });
 
-test('03 Install kubewarden', async({ page }) => {
+test('03 Install kubewarden', async({ page, ui }) => {
   const kwPage = new OverviewPage(page);
 
   await kwPage.installKubewarden();
 
   // Check UI is active
   await page.getByRole('navigation').getByRole('link', { name: 'Kubewarden' }).click();
-  try {
-    await expect(page.getByRole('heading', { name: 'Welcome to Kubewarden' })).toBeVisible();
-  } catch (e) {
-    console.log('Reload: Kubewarden installation done but not detected');
-    await page.reload();
-    await expect(page.getByRole('heading', { name: 'Welcome to Kubewarden' })).toBeVisible();
-  }
+  await ui.withReload(async () => {
+    await expect(page.getByRole('heading', { name: 'Welcome to Kubewarden' })).toBeVisible()
+  }, 'Kubewarden installation not detected')
 });
 
 test('04 Install default policyserver', async({ page, ui }) => {

--- a/tests/e2e/10-landing.spec.ts
+++ b/tests/e2e/10-landing.spec.ts
@@ -4,7 +4,7 @@ import { PolicyServersPage } from './pages/policyservers.page';
 import { AdmissionPoliciesPage } from './pages/admissionpolicies.page';
 import { ClusterAdmissionPoliciesPage } from './pages/clusteradmissionpolicies.page';
 
-test('Kubewarden Landing page', async({ page }) => {
+test('Kubewarden Landing page', async({ page, ui }) => {
   const kwPage = new OverviewPage(page);
   await kwPage.goto();
   await expect(page.getByRole('heading', { name: 'Welcome to Kubewarden' })).toBeVisible()
@@ -15,13 +15,10 @@ test('Kubewarden Landing page', async({ page }) => {
 
   await expect(page.getByText('Active 6 of 6 Global Policies / 100%')).toBeVisible({timeout:60_000})
   await expect(page.getByText('Active 0 of 0 Namespaced Policies / 0%')).toBeVisible()
-  try {
-    await expect(page.getByText('Active 1 of 1 Pods / 100%')).toBeVisible()
-  } catch (e) {
-    console.log('Reload: https://github.com/kubewarden/ui/issues/245')
-    await page.reload();
-    await expect(page.getByText('Active 1 of 1 Pods / 100%')).toBeVisible()
-  }
+
+  await ui.withReload(async () => {
+    expect(page.getByText('Active 1 of 1 Pods / 100%')).toBeVisible()
+  }, 'https://github.com/kubewarden/ui/issues/245')
 });
 
 test('Policy Servers Landing Page', async({ page, ui }) => {

--- a/tests/e2e/components/table-row.ts
+++ b/tests/e2e/components/table-row.ts
@@ -27,7 +27,7 @@ export class TableRow {
   }
 
   async toBeVisible() {
-    await this.row.waitFor()
+    await expect(this.row).toBeVisible()
   }
 
   async toBeActive(timeout = 200_000) {

--- a/tests/e2e/pages/basepolicypage.ts
+++ b/tests/e2e/pages/basepolicypage.ts
@@ -1,7 +1,6 @@
 import { expect } from '@playwright/test';
 import { BasePage } from './basepage';
 import { RancherUI } from './rancher-ui';
-import type { Locator, Page } from '@playwright/test';
 import { TableRow } from '../components/table-row';
 
 export const policyTitles = ['Custom Policy', 'Allow Privilege Escalation PSP', 'Allowed Fs Groups PSP', 'Allowed Proc Mount Types PSP', 'Apparmor PSP', 'Capabilities PSP',
@@ -58,13 +57,16 @@ export class BasePolicyPage extends BasePage {
   }
 
   async open(p: Policy) {
-    // Start from policies list
+    // Open list of policies
     await this.ui.createBtn.click()
     await expect(this.page.getByRole('heading', { name: 'Finish: Step 1' })).toBeVisible()
-
-    // Select policy, skip readme
-    await this.page.getByRole('heading', { name: p.title, exact: true }).click()
+    // Open requested policy
+    await this.ui.withReload(async () => {
+      await this.page.getByRole('heading', { name: p.title, exact: true }).click()
+    }, 'Could not get policy list from artifacthub')
+    // Go to values tab, skip optional readme
     await this.page.getByRole('tab', { name: 'Values' }).click()
+    await expect(this.page.getByRole('heading', { name: 'General' })).toBeVisible()
   }
 
   async setValues(p: Policy) {

--- a/tests/e2e/pages/rancher-extensions.page.ts
+++ b/tests/e2e/pages/rancher-extensions.page.ts
@@ -58,14 +58,9 @@ export class RancherExtensionsPage extends BasePage {
       await this.ui.select('Version', options.version)
     }
     await dialog.getByRole('button', { name: 'Install' }).click();
-
-    try {
-      await expect(plugin.getByRole('button', { name: 'Uninstall' })).toBeEnabled({timeout: 60_000});
-    } catch (e) {
-      console.log('Reload: Extension stuck in "Installing..."');
-      await this.page.reload();
-      await expect(plugin.getByRole('button', { name: 'Uninstall' })).toBeEnabled();
-    }
+    await this.ui.withReload(async () => {
+      await expect(plugin.getByRole('button', { name: 'Uninstall' })).toBeEnabled({timeout: 60_000})
+    }, 'Extension stuck in "Installing..."')
   }
 
   /**

--- a/tests/e2e/pages/rancher-ui.ts
+++ b/tests/e2e/pages/rancher-ui.ts
@@ -85,4 +85,14 @@ export class RancherUI {
         await page.keyboard.insertText(jsyaml.dump(cmYaml))
     }
 
+    async withReload(code: () => Promise<void>, message?: string): Promise<void> {
+        try {
+            await code();
+        } catch (e) {
+            if (message) console.log(`Reload: ${message}`)
+            await this.page.reload();
+            await code();
+        }
+    }
+
 }


### PR DESCRIPTION
Add wrapper for page reload after rancher fails to display page.

Contains fix for failed nightly job: https://github.com/kubewarden/kubewarden-ui/actions/runs/5640077752/job/15276162702
